### PR TITLE
[ Feat ] 브리핑 카드 조회 시 AccessToken 제거 및 FCM 연동

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -95,6 +95,7 @@ dependencies {
 
     implementation("androidx.constraintlayout:constraintlayout-compose:1.0.1")
     implementation 'androidx.compose.ui:ui-tooling-android:1.5.4'
+    implementation 'com.google.firebase:firebase-messaging-ktx:23.4.0'
     //Test Library
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
@@ -131,12 +132,15 @@ dependencies {
     implementation 'androidx.compose.runtime:runtime-livedata:1.3.2'
 
     //google social login
-    implementation 'com.google.android.gms:play-services-auth:20.7.0'
-    //analytics
+    implementation "com.google.android.gms:play-services-auth:20.7.0"
+
     implementation platform("com.google.firebase:firebase-bom:32.5.0")
+    //analytics
     implementation "com.google.firebase:firebase-analytics"
     //crashlytics
-    implementation("com.google.firebase:firebase-crashlytics")
+    implementation "com.google.firebase:firebase-crashlytics"
+    //fcm
+    implementation "com.google.firebase:firebase-messaging-ktx"
 
     implementation "androidx.work:work-runtime-ktx:$work_version"
 

--- a/app/src/main/java/com/dev/briefing/di/NetworkModule.kt
+++ b/app/src/main/java/com/dev/briefing/di/NetworkModule.kt
@@ -16,8 +16,8 @@ import retrofit2.converter.gson.GsonConverterFactory
 val networkModule = module {
     single {
         OkHttpClient.Builder()
-            .addInterceptor(HttpLoggingInterceptor().setLevel(HttpLoggingInterceptor.Level.BODY))
             .addInterceptor(AuthInterceptor(get()))
+            .addNetworkInterceptor(HttpLoggingInterceptor().setLevel(HttpLoggingInterceptor.Level.BODY))
             .build()
     }
 

--- a/app/src/main/java/com/dev/briefing/util/FCMService.kt
+++ b/app/src/main/java/com/dev/briefing/util/FCMService.kt
@@ -1,0 +1,86 @@
+package com.dev.briefing.util
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import androidx.core.app.NotificationCompat
+import com.dev.briefing.R
+import com.dev.briefing.presentation.login.SignInActivity
+import com.google.firebase.messaging.FirebaseMessagingService
+import com.google.firebase.messaging.RemoteMessage
+import com.orhanobut.logger.Logger
+
+class FCMService : FirebaseMessagingService() {
+
+    private val CHANNEL_ID = "notification_remote_channel"
+
+    private lateinit var notificationManager: NotificationManager
+
+    // Token 생성
+    override fun onNewToken(token: String) {
+        Logger.d("new Token: $token")
+    }
+
+    // foreground 메세지 수신시 동작 설정
+    override fun onMessageReceived(remoteMessage: RemoteMessage) {
+        Logger.d("From: " + remoteMessage.from)
+
+        // 받은 remoteMessage의 값 출력해보기. 데이터메세지 / 알림메세지
+        val messageData = "${remoteMessage.notification?.let {
+            "${it.title} ${it.body}"
+        }}"
+        Logger.d("Message data : $messageData")
+        Logger.d("Message notification : ${remoteMessage.notification?.imageUrl}")
+
+        if (messageData.isNotEmpty()) {
+            //알림 생성
+            sendNotification(remoteMessage)
+        } else {
+            Logger.e("data가 비어있습니다. 메시지를 수신하지 못했습니다.")
+        }
+    }
+
+    private fun createNotificationChannel() {
+        val importance = NotificationManager.IMPORTANCE_HIGH
+
+        val channel =
+            NotificationChannel(CHANNEL_ID, "notification_channel", importance)
+
+        notificationManager =
+            getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        notificationManager.createNotificationChannel(channel)
+    }
+
+    // 메세지 알림 생성
+    private fun sendNotification(remoteMessage: RemoteMessage) {
+        val pendingIntent = getFcmPendingIntent(this)
+
+        val notificationBuilder = NotificationCompat.Builder(this, CHANNEL_ID)
+            .setPriority(NotificationCompat.PRIORITY_HIGH)
+            .setSmallIcon(R.mipmap.ic_launcher) // 아이콘 설정
+            .setContentTitle(remoteMessage.notification?.title) // 제목
+            .setContentText(remoteMessage.notification?.body) // 메시지 내용
+            .setAutoCancel(true) // 알람클릭시 삭제여부
+            .setDefaults(Notification.DEFAULT_ALL) // 진동, 소리, 불빛 설정
+            .setPriority(NotificationCompat.PRIORITY_HIGH) // 헤드업 알림
+            .setContentIntent(pendingIntent) // 알림 실행 시 Intent
+
+        createNotificationChannel()
+        notificationManager.notify(System.currentTimeMillis().toInt(), notificationBuilder.build())
+    }
+
+    private fun getFcmPendingIntent(context: Context): PendingIntent {
+        val intent = Intent(context, SignInActivity::class.java)
+        intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+        return PendingIntent.getActivity(
+            context,
+            System.currentTimeMillis().toInt(),
+            intent,
+            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+        )
+    }
+
+}

--- a/app/src/main/java/com/dev/briefing/util/MainApplication.kt
+++ b/app/src/main/java/com/dev/briefing/util/MainApplication.kt
@@ -1,6 +1,7 @@
 package com.dev.briefing.util
 
 import android.app.Application
+import android.util.Log
 import com.dev.briefing.BuildConfig
 import com.dev.briefing.di.androidSystemModule
 import com.dev.briefing.di.dataSourceModule
@@ -10,6 +11,7 @@ import com.dev.briefing.di.preferenceModule
 import com.dev.briefing.di.repositoryModule
 import com.dev.briefing.di.viewModelModule
 import com.google.android.gms.ads.RequestConfiguration
+import com.google.firebase.messaging.FirebaseMessaging
 import com.orhanobut.logger.AndroidLogAdapter
 import com.orhanobut.logger.Logger
 import org.koin.android.ext.koin.androidContext
@@ -19,6 +21,7 @@ class MainApplication : Application() {
 
     override fun onCreate() {
         super.onCreate()
+
         // initialize log library
         Logger.addLogAdapter(object : AndroidLogAdapter() {
             override fun isLoggable(priority: Int, tag: String?): Boolean {
@@ -27,6 +30,14 @@ class MainApplication : Application() {
         })
 
         RequestConfiguration.Builder().setTestDeviceIds(listOf(BuildConfig.ADMOB_TEST_DEVICE_1))
+        FirebaseMessaging.getInstance().token.addOnCompleteListener { task ->
+            if (task.isSuccessful) {
+                val token = task.result
+                Logger.d("Fetching FCM registration token succeed : $token")
+            } else {
+                Logger.w("Fetching FCM registration token failed", task.exception)
+            }
+        }
 
         startKoin {
             androidContext(this@MainApplication)


### PR DESCRIPTION
## ‼️ 관련 이슈
> 관련 이슈를 링크해주세요
- [[ Feat ] 브리핑 카드 조회 시 AccessToken 제거 및 FCM 연동 #61](https://github.com/Team-Shaka/Briefing-Android/issues/61)

## ✨ PR Point
> 해당 PR에 대해 간략하게 작성해주세요
- 브리핑 카드 상세 조회 API가 dev 환경일 때는 정상 작동하나 prod 환경일 때는 토큰 관련 500에러가 발생합니다. 해당 API 요청만 일단 액세스 토큰을 보내지 않도록 처리했습니다.
- FCM 연동을 완료했습니다.

## To Reviewers
> 참고사항및 특이점이 있으면 적어주세요
- 후에 브리핑 카드 상세 조회 API가 고쳐진다면 원상태로 돌려놓아야할 것 같습니다.
- FCM 토큰 등록 API가 나온다면 토큰 등록 및 서버에 전송하는 로직 작성이 따로 필요합니다.
